### PR TITLE
Call ClosureCompilerPlugin.runCompiler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -199,7 +199,7 @@ Use the CommonsChunkPlugin to ensure a module exists in only one bundle.`,
         module_wrapper: moduleWrappers,
       });
 
-    const compilerProcess = this.runCompiler(compilationOptions, (exitCode, stdOutData, stdErrData) => {
+    const compilerProcess = ClosureCompilerPlugin.runCompiler(compilationOptions, (exitCode, stdOutData, stdErrData) => {
       if (stdErrData instanceof Error) {
         this.reportErrors({
           level: 'error',
@@ -285,7 +285,7 @@ Use the CommonsChunkPlugin to ensure a module exists in only one bundle.`,
    * @return {!ChildProcess}
    */
   static runCompiler(flags, doneCallback) {
-    const compilerRunner = new ClosureCompiler(flags, doneCallback);
+    const compilerRunner = new ClosureCompiler(flags);
     compilerRunner.spawnOptions = { stdio: 'pipe' };
     const compilerProcess = compilerRunner.run();
 


### PR DESCRIPTION
This is a partial fix for #12, making it so `mode: 'AGGRESSIVE_BUNDLE'` works.  I didn't address the `'STANDARD'` mode part of the issue.
