### PR TITLE
Correct logic that selected the wrong version of the runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "closure-webpack-plugin",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Webpack Google Closure Compiler plugin",
   "author": "Chad Killingsworth (@ChadKillingsworth)",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -462,8 +462,8 @@ Use the CommonsChunkPlugin to ensure a module exists in only one bundle.`,
    * @param {boolean} lateLoadingSupport
    * @return {string}
    */
-  static renderRuntime(scriptSrcPath, lateLoadingSupport = false) {
-    const runtimePath = lateLoadingSupport ? './basic-runtime.js' : './runtime.js';
+  static renderRuntime(scriptSrcPath, lateLoadingSupport) {
+    const runtimePath = lateLoadingSupport ? './runtime.js' : './basic-runtime.js';
     return `${fs.readFileSync(require.resolve(runtimePath), 'utf8')}
 __webpack_require__.src = function(chunkId) {
   return __webpack_require__.p + ${scriptSrcPath};


### PR DESCRIPTION
I had the logic flipped, so the JSONP runtime was being omitted from code splitting compilations and included in single file compilations.