### PR TITLE
Correctly detect whether a compilation is a child

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,27 @@ new ClosureCompilerPlugin({mode: 'STANDARD'}, {
 ## Options
 
  * **mode** - `STANDARD` (default) or `AGGRESSIVE_BUNDLE`. Controls how the plugin utilizes the compiler.  
-    In `STANDARD` mode, closure-compiler is used as a direct replacement for other minifiers as well as most Babel transformations.  
-    In `AGGRESSIVE_BUNDLE` mode, the compiler performs additional optimizations of modules to produce a much smaller file, but
+    - In `STANDARD` mode, closure-compiler is used as a direct replacement for other minifiers as well as most Babel transformations.  
+    - In `AGGRESSIVE_BUNDLE` mode, the compiler performs additional optimizations of modules to produce a much smaller file, but
 is not compatible with all input modules.
+ * **childCompilations** - boolean or function. Defaults to `false`.
+  In order to decrease build times, this plugin by default only operates on the main compilation.
+  Plugins such as extract-text-plugin and html-webpack-plugin run as child compilations and
+  usually do not need transpilation or minification. You can enable this for all child compilations
+  by setting this option to `true`. For specific control, the option can be set to a function which
+  will be passed a compilation object.  
+  Example: `function(compilation) { return /html-webpack/.test(compilation.name); }`.
 
 ## Compiler Flags
 
-The plugin controls certain compiler flags. The following flags should not be used in any mode:
+The plugin controls several compiler flags. The following flags should not be used in any mode:
 
- * **module_resolution** - A custom resolution mode for webpack is utilized instead of the standard NODE or BROWSER options.
- * **output_wrapper** - The output wrapper is automatically added by either webpack or the plugin
- * **dependency_mode** - Controlled by the plugin mode.
+ * module_resolution
+ * output_wrapper
+ * dependency_mode
+ * create_souce_map
+ * module
+ * entry_point
 
 ## Aggressive Bundle Mode
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "closure-webpack-plugin",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "closure-webpack-plugin",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Webpack Google Closure Compiler plugin",
   "author": "Chad Killingsworth (@ChadKillingsworth)",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,13 @@ class ClosureCompilerPlugin {
   constructor(options, compilerFlags) {
     this.options = options || {};
     this.compilerFlags = compilerFlags || {};
+    if (typeof this.options.childCompilations === 'boolean') {
+      this.options.childCompilations = function childCompilationSupported(childrenSupported) {
+        return childrenSupported;
+      }.bind(this, this.options.childCompilations);
+    } else if (typeof this.options.childCompilations !== 'function') {
+      this.options.childCompilations = function childCompilationSupported() { return false; };
+    }
   }
 
   apply(compiler) {
@@ -68,13 +75,6 @@ class ClosureCompilerPlugin {
       }
 
       compilation.plugin('optimize-chunk-assets', (originalChunks, cb) => {
-        // Disable the compiler for child compilations which are named.
-        // Probably want an option to control this.
-        if (compilation.name) {
-          cb();
-          return;
-        }
-
         if (this.options.mode === 'AGGRESSIVE_BUNDLE') {
           this.aggressiveBundle(compilation, originalChunks, cb);
         } else {


### PR DESCRIPTION
Compilations were incorrectly being skipped as the logic to detect a child compilation was simply looking for a name on the compilation. This now looks for a `parentCompilation` property and also adds an option to control whether the plugin should apply for any given child compilation.

Fixes #24 