### PR TITLE
Add a warning for closure namespaces which cannot be found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "closure-webpack-plugin",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "closure-webpack-plugin",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Webpack Google Closure Compiler and Closure Library plugin",
   "author": "Chad Killingsworth (@ChadKillingsworth)",
   "license": "MIT",

--- a/src/goog-require-parser-plugin.js
+++ b/src/goog-require-parser-plugin.js
@@ -58,7 +58,7 @@ class GoogRequireParserPlugin {
             ) {
               googDepsByPath.set(
                 filePath,
-                node.arguments[2].elements.map((node) => node.value)
+                node.arguments[2].elements.map((nodeVal) => nodeVal.value)
               );
             }
           }
@@ -109,7 +109,7 @@ class GoogRequireParserPlugin {
             new GoogDependency(modulePath, insertPosition)
           );
         } catch (e) {
-          console.error(e);
+          parser.state.compilation.errors.push(e);
         }
         return false;
       }
@@ -128,8 +128,9 @@ class GoogRequireParserPlugin {
           parser.state.current.contextArgument = function() {
             return 'window';
           };
-          const variableInjectionFunctionWrapperEndCode =
-            parser.state.current.variableInjectionFunctionWrapperEndCode;
+          const {
+            variableInjectionFunctionWrapperEndCode,
+          } = parser.state.current;
           parser.state.current.variableInjectionFunctionWrapperEndCode = function(
             varExpressions,
             block

--- a/src/goog-require-parser-plugin.js
+++ b/src/goog-require-parser-plugin.js
@@ -89,6 +89,12 @@ class GoogRequireParserPlugin {
         try {
           const param = expr.arguments[0].value;
           const modulePath = this.googPathsByNamespace.get(param);
+          if (!modulePath) {
+            parser.state.compilation.warnings.push(
+              new Error(`Unable to locate module for namespace: ${param}`)
+            );
+            return false;
+          }
           const insertPosition =
             this.options.mode === 'NONE' ? expr.start : null;
           if (this.googDepsByPath.has(modulePath)) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -43,7 +43,7 @@ if (typeof _WEBPACK_MODULE_CACHE_ === 'undefined') {
     var executionCallback = cb;
     while (resolves.length) {
       resolves.shift()(cb);
-      executionCallback = undefined;
+      executionCallback = undefined; // eslint-disable-line no-undefined
     }
   };
 })();
@@ -78,7 +78,7 @@ function _webpack_load_chunk_(chunkId, basePromise) {
   installedChunkData[2] = promise;
 
   // start chunk loading
-  var head = document.getElementsByTagName('head')[0];
+  var head = document.getElementsByTagName('head')[0]; // eslint-disable-line prefer-destructuring
   var script = document.createElement('script');
   script.type = 'text/javascript';
   script.charset = 'utf-8';
@@ -100,7 +100,7 @@ function _webpack_load_chunk_(chunkId, basePromise) {
       if (chunk) {
         chunk[1](new Error('Loading chunk ' + chunkId + ' failed.'));
       }
-      _WEBPACK_MODULE_CACHE_[chunkId] = undefined;
+      _WEBPACK_MODULE_CACHE_[chunkId] = undefined; // eslint-disable-line no-undefined
     }
   }
   head.appendChild(script);
@@ -127,6 +127,6 @@ __webpack_require__.e = function() {
  * @param {Error} err
  */
 __webpack_require__.oe = function(err) {
-  console.error(err);
+  console.error(err); // eslint-disable-line no-console
   throw err;
 };

--- a/test/helpers/compiler.js
+++ b/test/helpers/compiler.js
@@ -3,7 +3,7 @@ import del from 'del';
 import webpack from 'webpack';
 import MemoryFS from 'memory-fs';
 
-const majorVersion = require('webpack/package.json').version.split('.')[0];
+const [majorVersion] = require('webpack/package.json').version.split('.');
 
 const modules = (config) => {
   return {


### PR DESCRIPTION
The closure namespace plugin created errors if a required namespace could not be located. Issue a nicely formatted error message and continue.