### PR TITLE
Add a goog base dependency for goog module calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "closure-webpack-plugin",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Webpack Google Closure Compiler and Closure Library plugin",
   "author": "Chad Killingsworth (@ChadKillingsworth)",
   "license": "MIT",

--- a/src/goog-require-parser-plugin.js
+++ b/src/goog-require-parser-plugin.js
@@ -149,6 +149,17 @@ class GoogRequireParserPlugin {
       });
       parser.plugin('call goog.module', (expr) => {
         if (this.options.mode === 'NONE') {
+          if (
+            !parser.state.current.hasDependencies(
+              (dep) => dep.request === this.basePath
+            )
+          ) {
+            const baseInsertPos = this.options.mode === 'NONE' ? 0 : null;
+            parser.state.current.addDependency(
+              new GoogDependency(this.basePath, baseInsertPos)
+            );
+          }
+
           const prefixDep = parser.state.current.dependencies.find(
             (dep) => dep instanceof GoogLoaderPrefixDependency
           );


### PR DESCRIPTION
Make sure any module that references `goog.module` has a dependency on closure-library's base.js.

Fixes: #44 