### PR TITLE
refactor: remove unnecessary condition

### DIFF
--- a/src/goog-require-parser-plugin.js
+++ b/src/goog-require-parser-plugin.js
@@ -154,7 +154,7 @@ class GoogRequireParserPlugin {
               (dep) => dep.request === this.basePath
             )
           ) {
-            const baseInsertPos = this.options.mode === 'NONE' ? 0 : null;
+            const baseInsertPos = 0;
             parser.state.current.addDependency(
               new GoogDependency(this.basePath, baseInsertPos)
             );


### PR DESCRIPTION
This is always `0` because it's in the statement.

```js
if (this.options.mode === 'NONE') {
}
```

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
