### PR TITLE
fix: reset the errors array to undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -502,6 +502,8 @@ Use the CommonsChunkPlugin to ensure a module exists in only one bundle.`,
                   description: stdErrData.substr(exceptionIndex + 1),
                 });
               } catch (e2) {}
+            } else {
+              errors = undefined;
             }
           }
 


### PR DESCRIPTION
When closure-compiler returned error data that could not be parsed, compilation was silently failing. Fixes the issue so that un-parsable errors are still reported.