### PR TITLE
fix: correct asset naming when using a custom naming template

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -274,10 +274,7 @@ class ClosureCompilerPlugin {
               } else {
                 assetName = outputFile.path.replace(/^\.\//, '');
                 if (!/\.js$/.test(chunk.files[0])) {
-                  assetName = outputFile.path.substr(
-                    0,
-                    outputFile.path.length - 3
-                  );
+                  assetName = assetName.substr(0, assetName.length - 3);
                 }
               }
               const sourceMap = JSON.parse(outputFile.source_map);


### PR DESCRIPTION
The asset name was being incorrectly generated - the leading `./` added by closure-compiler was not being stripped.