### PR TITLE
feature: add "entryChunks" option to allow ModuleManager lazyloading

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -63,6 +63,13 @@
           "$ref": "#/definitions/platform"
         }
       }]
+    },
+    "entryChunks": {
+      "description": "Chunks regarded as entry chunks, will not be wrapped by webpackJsonp",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -437,7 +437,7 @@ Use the CommonsChunkPlugin to ensure a module exists in only one bundle.`,
           }
         });
 
-        if (parentChunk !== null) {
+        if (this.options.entryChunks.indexOf(chunk.id) < 0 && parentChunk !== null) {
           return `${defParts[0]}:webpackJsonp([${
             chunk.id
           }], function(__wpcc){%s});`;

--- a/src/index.js
+++ b/src/index.js
@@ -438,7 +438,7 @@ Use the CommonsChunkPlugin to ensure a module exists in only one bundle.`,
         });
 
         if (
-          this.options.entryChunks.indexOf(chunk.id) < 0 &&
+          this.options.entryChunks.indexOf(chunk.name) < 0 &&
           parentChunk !== null
         ) {
           return `${defParts[0]}:webpackJsonp([${

--- a/src/index.js
+++ b/src/index.js
@@ -437,7 +437,10 @@ Use the CommonsChunkPlugin to ensure a module exists in only one bundle.`,
           }
         });
 
-        if (this.options.entryChunks.indexOf(chunk.id) < 0 && parentChunk !== null) {
+        if (
+          this.options.entryChunks.indexOf(chunk.id) < 0 &&
+          parentChunk !== null
+        ) {
           return `${defParts[0]}:webpackJsonp([${
             chunk.id
           }], function(__wpcc){%s});`;


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
Please refer to [this issue](https://github.com/webpack-contrib/closure-webpack-plugin/issues/72)
