### PR TITLE
Support goog.module.ModuleManager js resource lazy loading

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -63,6 +63,13 @@
           "$ref": "#/definitions/platform"
         }
       }]
+    },
+    "entryChunks": {
+      "description": "Chunks regarded as entry chunks, will not be wrapped by webpackJsonp",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -64,8 +64,8 @@
         }
       }]
     },
-    "entryChunks": {
-      "description": "Chunks regarded as entry chunks, will not be wrapped by webpackJsonp",
+    "runtimeNeedlessChunks": {
+      "description": "Chunks that don't need webpack runtime, which is useful when use goog.module.ModuleManager for lazy loading",
       "type": "array",
       "items": {
         "type": "string"

--- a/src/index.js
+++ b/src/index.js
@@ -437,7 +437,7 @@ Use the CommonsChunkPlugin to ensure a module exists in only one bundle.`,
           }
         });
 
-        if (parentChunk !== null) {
+        if (this.options.entryChunks.indexOf(chunk.id) < 0 && parentChunk !== null) {
           return `${defParts[0]}:webpackJsonp([${
             chunk.id
           }], function(__wpcc){%s});`;

--- a/src/index.js
+++ b/src/index.js
@@ -327,6 +327,15 @@ class ClosureCompilerPlugin {
     let uniqueId = 1;
     let jsonpRuntimeRequired = false;
     const entryPoints = new Set();
+    if (
+      this.options.runtimeNeedlessChunks &&
+      Array.isArray(this.options.runtimeNeedlessChunks)
+    ) {
+      originalChunks.forEach((chunk) => {
+        chunk.runtimeNeedless =
+          this.options.runtimeNeedlessChunks.indexOf(chunk.name) >= 0;
+      });
+    }
     originalChunks.forEach((chunk) => {
       if (chunk.hasEntryModule()) {
         if (chunk.entryModule.userRequest) {
@@ -353,10 +362,7 @@ class ClosureCompilerPlugin {
 
       // The jsonp runtime must be injected if at least one module
       // is late loaded (doesn't include the runtime)
-      if (
-        !chunk.hasRuntime() &&
-        this.options['runtimeNeedlessChunks'].indexOf(chunk.name) < 0
-      ) {
+      if (!chunk.hasRuntime() && !chunk.runtimeNeedless) {
         jsonpRuntimeRequired = true;
       }
     });
@@ -440,10 +446,7 @@ Use the CommonsChunkPlugin to ensure a module exists in only one bundle.`,
           }
         });
 
-        if (
-          this.options['runtimeNeedlessChunks'].indexOf(chunk.name) < 0 &&
-          parentChunk !== null
-        ) {
+        if (parentChunk !== null && !chunk.runtimeNeedless) {
           return `${defParts[0]}:webpackJsonp([${
             chunk.id
           }], function(__wpcc){%s});`;

--- a/src/index.js
+++ b/src/index.js
@@ -438,7 +438,7 @@ Use the CommonsChunkPlugin to ensure a module exists in only one bundle.`,
         });
 
         if (
-          this.options.entryChunks.indexOf(chunk.id) < 0 &&
+          this.options.entryChunks.indexOf(chunk.name) < 0 &&
           parentChunk !== null
         ) {
           return `${defParts[0]}:webpackJsonp([${

--- a/src/index.js
+++ b/src/index.js
@@ -353,7 +353,10 @@ class ClosureCompilerPlugin {
 
       // The jsonp runtime must be injected if at least one module
       // is late loaded (doesn't include the runtime)
-      if (!chunk.hasRuntime()) {
+      if (
+        !chunk.hasRuntime() &&
+        this.options['runtimeNeedlessChunks'].indexOf(chunk.name) < 0
+      ) {
         jsonpRuntimeRequired = true;
       }
     });
@@ -438,7 +441,7 @@ Use the CommonsChunkPlugin to ensure a module exists in only one bundle.`,
         });
 
         if (
-          this.options.entryChunks.indexOf(chunk.name) < 0 &&
+          this.options['runtimeNeedlessChunks'].indexOf(chunk.name) < 0 &&
           parentChunk !== null
         ) {
           return `${defParts[0]}:webpackJsonp([${

--- a/src/index.js
+++ b/src/index.js
@@ -437,7 +437,10 @@ Use the CommonsChunkPlugin to ensure a module exists in only one bundle.`,
           }
         });
 
-        if (this.options.entryChunks.indexOf(chunk.id) < 0 && parentChunk !== null) {
+        if (
+          this.options.entryChunks.indexOf(chunk.id) < 0 &&
+          parentChunk !== null
+        ) {
           return `${defParts[0]}:webpackJsonp([${
             chunk.id
           }], function(__wpcc){%s});`;


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
Please refer to [this issue](https://github.com/webpack-contrib/closure-webpack-plugin/issues/72).
goog.module.ModuleManager style js resource lazy loading is different from webpack managed dynamic imports. It doesn't need the support of webpack runtime, which in fact will fail it.
I add 'runtimeNeedlessChunks' option for user to specify those chunks which don't need runtime.