### PR TITLE
feat: allow passing extra command args to java closure compiler

### DIFF
--- a/schema/closure-compiler.json
+++ b/schema/closure-compiler.json
@@ -109,6 +109,17 @@
           "type": "array"
         }
       ]
+    },
+    "extraCommandArgs": {
+      "description": "Extra command arguments passed to java version of closure-compiler",
+      "oneOf": [{
+        "type": "string"
+      }, {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }]
     }
   }
 }

--- a/src/closure-compiler-plugin.js
+++ b/src/closure-compiler-plugin.js
@@ -94,6 +94,10 @@ class ClosureCompilerPlugin {
       this.options.platform = [this.options.platform];
     }
 
+    if (!Array.isArray(this.options.extraCommandArgs)) {
+      this.options.extraCommandArgs = [this.options.extraCommandArgs];
+    }
+
     if (this.options.mode === 'STANDARD') {
       this.compilerFlags = Object.assign(
         {},
@@ -892,7 +896,10 @@ class ClosureCompilerPlugin {
         json_streams: 'BOTH',
       });
       const { compiler: ClosureCompiler } = googleClosureCompiler;
-      const compilerRunner = new ClosureCompiler(flags);
+      const compilerRunner = new ClosureCompiler(
+        flags,
+        this.options.extraCommandArgs
+      );
       compilerRunner.spawnOptions = { stdio: 'pipe' };
       if (platform.toLowerCase() === 'native') {
         compilerRunner.JAR_PATH = null;
@@ -1305,6 +1312,7 @@ ClosureCompilerPlugin.DEFAULT_OPTIONS = {
   mode: 'STANDARD',
   platform: ['native', 'java', 'javascript'],
   test: /\.js(\?.*)?$/i,
+  extraCommandArgs: [],
 };
 
 /** @const */


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
Please refer to #84 .