### PR TITLE
Fix chunk minification

### DIFF
--- a/src/closure-compiler-plugin.js
+++ b/src/closure-compiler-plugin.js
@@ -1165,7 +1165,7 @@ class ClosureCompilerPlugin {
           childGroup.chunks.forEach((childChunk) => {
             chunksToAdd.unshift({
               chunk: childChunk,
-              parentNames: [safeChunkName],
+              parentChunkNames: [safeChunkName],
             });
           });
           chunkQueue.push(...chunksToAdd);

--- a/src/closure-compiler-plugin.js
+++ b/src/closure-compiler-plugin.js
@@ -155,11 +155,11 @@ class ClosureCompilerPlugin {
       );
     }
     compiler.hooks.compilation.tap(PLUGIN, (compilation, params) =>
-      this.complation_(compilation, params)
+      this.compilation_(compilation, params)
     );
   }
 
-  complation_(compilation, { normalModuleFactory }) {
+  compilation_(compilation, { normalModuleFactory }) {
     const runFullCompilation =
       !compilation.compiler.parentCompilation ||
       this.options.childCompilations(compilation);
@@ -1132,10 +1132,10 @@ class ClosureCompilerPlugin {
         let src = '';
         let sourceMap = null;
         try {
-          const souceAndMap = compilation.assets[chunkFile].sourceAndMap();
-          src = souceAndMap.source;
-          if (souceAndMap.map) {
-            sourceMap = souceAndMap.map;
+          const sourceAndMap = compilation.assets[chunkFile].sourceAndMap();
+          src = sourceAndMap.source;
+          if (sourceAndMap.map) {
+            sourceMap = sourceAndMap.map;
           }
         } catch (e) {
           compilation.errors.push(e);


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

Hi,

This PR fixes the issue described https://github.com/webpack-contrib/closure-webpack-plugin/issues/52#issuecomment-573141682.
Chunks were not correctly processed in standard mode, because the field that holds the chunk's parents was used inconsistently. The first entry contained a `parentChunkNames` and the followup entries contained `parentNames` instead. This broke the destructuring assignment and led to `parentChunkNames` being `undefined` all the time.