### PR TITLE
comma leftover in the code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ module.exports = {
       ),
       deps: [
         require.resolve('google-closure-library/closure/goog/deps'),
-        './public/deps.js',
+        './public/deps.js'
       ],
     })
   ]


### PR DESCRIPTION
Simple `,` (comma) leftover in the README.md