### PR TITLE
fix: Ignore Java warnings on stderr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,6 @@ jobs:
           name: Publish to NPM
           command: printf "noop running conventional-github-releaser"
 
-version: 2.0
 workflows:
   version: 2
   validate-publish:

--- a/src/closure-compiler-plugin.js
+++ b/src/closure-compiler-plugin.js
@@ -1003,6 +1003,14 @@ class ClosureCompilerPlugin {
           return;
         }
 
+        if (platform.toLowerCase() === 'java') {
+          // Ignore Java warnings written to stderr
+          stdErrData = stdErrData
+            .split('\n')
+            .filter((e) => !e.startsWith('WARNING: '))
+            .join('\n');
+        }
+
         if (stdErrData.length > 0) {
           let errors = [];
           try {


### PR DESCRIPTION
Java warnings are written to stderr, which can cause false positives handling output from the Closure Compiler. This can be reproduced by adding `conformance_configs` to the GCC options and using `platform: 'java'`, which produces output like the following:

```
ERROR in closure-compiler: WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.protobuf.UnsafeUtil (file:/<path omitted>/node_modules/google-closure-compiler-java/compiler.jar) to field java.nio.Buffer.address
WARNING: Please consider reporting this to the maintainers of com.google.protobuf.UnsafeUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
[{"level":"info","description":"0 error(s), 0 warning(s)"}]
```

The [Java conformance check](https://github.com/google/closure-compiler/blob/5a1376ad337228a9d4bd6cef352b4c8d4eb83a9b/src/com/google/javascript/jscomp/CheckConformance.java) uses protobuf, triggering the above warnings which are treated as errors by this plugin.

I also removed a duplicate `version` key in the CircleCI config to fix the build error.