### PR TITLE
fix: use safe path in source maps

### DIFF
--- a/src/closure-compiler-plugin.js
+++ b/src/closure-compiler-plugin.js
@@ -865,7 +865,10 @@ class ClosureCompilerPlugin {
           chunkNamesProcessed.add(chunkDefArray[i].name);
           chunkDefArray[i].sources.forEach((srcInfo) => {
             if (srcInfo.sourceMap) {
-              srcInfo.sourceMap = JSON.stringify(srcInfo.sourceMap);
+              srcInfo.sourceMap = JSON.stringify({
+                ...srcInfo.sourceMap,
+                sources: srcInfo.sourceMap.sources.map(toSafePath)
+              });
             }
             allSources.push(srcInfo);
           });

--- a/src/safe-path.js
+++ b/src/safe-path.js
@@ -3,5 +3,5 @@
  * Given a path, replace all characters not recognized by closure-compiler with a '$'
  */
 module.exports = function toSafePath(originalPath) {
-  return originalPath.replace(/[:,]+/g, '$');
+  return originalPath.replace(/[:,?]+/g, '$');
 };


### PR DESCRIPTION
Should solve https://github.com/webpack-contrib/closure-webpack-plugin/issues/100, or at least avoid errors caused by said paths being used in source maps.
