### PR TITLE
Fix EPIPE error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,6 @@ jobs:
           name: Publish to NPM
           command: printf "noop running conventional-github-releaser"
 
-version: 2.0
 workflows:
   version: 2
   validate-publish:

--- a/src/closure-compiler-plugin.js
+++ b/src/closure-compiler-plugin.js
@@ -1045,6 +1045,9 @@ class ClosureCompilerPlugin {
         resolve(outputFiles);
       });
 
+      // Ignore errors (EPIPE) if the compiler input stream is closed
+      compilerProcess.stdin.on('error', (err) => {});
+
       const buffer = new Buffer(JSON.stringify(sources), 'utf8');
       const readable = new Readable();
       readable._read = () => {};

--- a/src/closure-compiler-plugin.js
+++ b/src/closure-compiler-plugin.js
@@ -1048,7 +1048,7 @@ class ClosureCompilerPlugin {
       // Ignore errors (EPIPE) if the compiler input stream is closed
       compilerProcess.stdin.on('error', (err) => {});
 
-      const buffer = new Buffer(JSON.stringify(sources), 'utf8');
+      const buffer = Buffer.from(JSON.stringify(sources), 'utf8');
       const readable = new Readable();
       readable._read = () => {};
       readable.push(buffer);


### PR DESCRIPTION
The EPIPE error described in #118 and fixed in #121 may still happen when the compiler exits early. This can be reproduced by providing invalid options to the compiler, such as:

```javascript
{
  'jscomp_error': [
    'notAnError'
  ]
}
```

Ignoring the error on stdin correctly reports the error from the compiler:

```
ERROR in closure-compiler: java.lang.NullPointerException: No warning class for name: notAnError
```

I also fixed the [Node Buffer deprecation warning](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/) following the first variant, given it is compatible with the current Node `engines` range.

The CircleCI build was failing due to a duplicate `version` tag, so I fixed that as well.