### PR TITLE
fix: sourcemap paths fail to resolve when using loaders

### DIFF
--- a/demo/es5-and-es6/package-lock.json
+++ b/demo/es5-and-es6/package-lock.json
@@ -5639,9 +5639,9 @@
       }
     },
     "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
     },
     "which": {

--- a/src/safe-path.js
+++ b/src/safe-path.js
@@ -3,5 +3,5 @@
  * Given a path, replace all characters not recognized by closure-compiler with a '$'
  */
 module.exports = function toSafePath(originalPath) {
-  return originalPath.replace(/[:,]+/g, '$');
+  return originalPath.replace(/[:,?]+/g, '$');
 };


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
Fixes #100 . This builds on PR #145 which I found makes the build pass, but doesn't produce valid source maps.

It appears that closure doesn't support the `loader-name?ref!filepath` "path" format that webpack uses for loaders, and also struggles with Windows (`\`) format. The loader path isn't really useful in source maps, especially when content is included by default, so I've sanitized these paths by just stripping off the loader prefix. If there is no valid path before loaders, I simply use `toSafePath` .

All of this is only within the `sourceMap` config, so does not affect JS.