### PR TITLE
fix: Infinite loops when circular dependency in parent chunks

### DIFF
--- a/src/closure-compiler-plugin.js
+++ b/src/closure-compiler-plugin.js
@@ -1124,6 +1124,7 @@ class ClosureCompilerPlugin {
         parentChunkNames: initialParentChunkNames,
       },
     ];
+    const chunksEverInQueue = new Set([initialChunk.id]);
     while (chunkQueue.length > 0) {
       const { chunk, parentChunkNames } = chunkQueue.pop();
       const chunkName = this.getChunkName(compilation, chunk);
@@ -1167,10 +1168,13 @@ class ClosureCompilerPlugin {
         for (const childGroup of group.childrenIterable) {
           const chunksToAdd = [];
           childGroup.chunks.forEach((childChunk) => {
-            chunksToAdd.unshift({
-              chunk: childChunk,
-              parentChunkNames: [safeChunkName],
-            });
+            if (!chunksEverInQueue.has(childChunk.id)) {
+              chunksEverInQueue.add(childChunk.id);
+              chunksToAdd.unshift({
+                chunk: childChunk,
+                parentChunkNames: [safeChunkName],
+              });
+            }
           });
           chunkQueue.push(...chunksToAdd);
         }

--- a/src/common-ancestor.js
+++ b/src/common-ancestor.js
@@ -14,6 +14,7 @@ function findAncestorDistance(initialSrc, target, initialDistance) {
       currentDistance: initialDistance,
     },
   ];
+  const visitedChunks = new Set([initialSrc]);
   while (parentChunkQueue.length > 0) {
     const { src, currentDistance } = parentChunkQueue.pop();
     if (target === src) {
@@ -23,10 +24,13 @@ function findAncestorDistance(initialSrc, target, initialDistance) {
     } else {
       const parentChunkGroups = src.getParents();
       for (let i = parentChunkGroups.length - 1; i >= 0; i--) {
-        parentChunkQueue.push({
-          src: parentChunkGroups[i],
-          currentDistance: currentDistance + 1,
-        });
+        if (!visitedChunks.has(parentChunkGroups[i])) {
+          visitedChunks.add(parentChunkGroups[i]);
+          parentChunkQueue.push({
+            src: parentChunkGroups[i],
+            currentDistance: currentDistance + 1,
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
Fixes #129, and an additional infinite loop I'm seeing when the parentChunkGroups has a circular dependency.

It looks like it's possible (and valid?) for Webpack to automatically produce a circular dependency between chunk groups when split chunks is automatically separating common code. In `STANDARD` mode, this doesn't produce any problems for closure, but the plugin is getting stuck in loops while building up the config to pass to Closure.

In both cases, simply keeping track of which chunks have already been processed is enough to prevent the loop here.