### PR TITLE
fix: CI by removing duplicate version field

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,6 @@ jobs:
           name: Publish to NPM
           command: printf "noop running conventional-github-releaser"
 
-version: 2.0
 workflows:
   version: 2
   validate-publish:


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
Looks like all CI builds are failing with the error
```
#!/bin/sh -eo pipefail
# Unable to parse YAML
# while constructing a mapping
#  in 'string', line 1, column 1:
#     unit_tests: &unit_tests
#     ^
# found duplicate key version
#  in 'string', line 112, column 1:
#     version: 2.0
#     ^
```

The `version:` field is indeed declared twice in the config (with the same value), so I'm removing one to fix.