### PR TITLE
Ensure error is logged when Closure fails

### DIFF
--- a/src/closure-compiler-plugin.js
+++ b/src/closure-compiler-plugin.js
@@ -968,10 +968,12 @@ class ClosureCompilerPlugin {
 
       compilerProcess.on('close', (exitCode) => {
         if (stdErrData instanceof Error) {
-          this.reportErrors({
+          this.reportErrors(compilation, [
+            {
             level: 'error',
             description: stdErrData.message,
-          });
+            }
+          ]);
           reject();
           return;
         }
@@ -1007,6 +1009,13 @@ class ClosureCompilerPlugin {
 
           this.reportErrors(compilation, errors);
           // TODO(ChadKillingsworth) Figure out how to report the stats
+        } else if (exitCode > 0) {
+          this.reportErrors(compilation, [
+            {
+              level: 'error',
+              description: `Closure compiler exited with code ${exitCode}.`,
+            }
+          ]);
         }
 
         if (exitCode > 0) {

--- a/src/closure-compiler-plugin.js
+++ b/src/closure-compiler-plugin.js
@@ -970,9 +970,9 @@ class ClosureCompilerPlugin {
         if (stdErrData instanceof Error) {
           this.reportErrors(compilation, [
             {
-            level: 'error',
-            description: stdErrData.message,
-            }
+              level: 'error',
+              description: stdErrData.message,
+            },
           ]);
           reject();
           return;
@@ -1014,7 +1014,7 @@ class ClosureCompilerPlugin {
             {
               level: 'error',
               description: `Closure compiler exited with code ${exitCode}.`,
-            }
+            },
           ]);
         }
 


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
Fixes #162.

Whenever the compiler process exits with non-zero code, we should be reporting some error back to Webpack.

It looks like the on close for compilerProcess has some custom error (and warning?) handling around parsing stderr, but simply calls `reject()` with no error at the end. The result is for non-zero exit but no stderr we reject, but never pass an error to Webpack.

I think most cases could be cleaned up by passing the error through `reject(error)` instead of `this.reportErrors(compilation, [error])`, but not if the stdout parsing logic found warnings but no errors. Instead I've opted to just add another case here that's handled, but I'm not 100% sure there are no other edge cases here.