### PR TITLE
fix: compile on Windows when path contains |

### DIFF
--- a/src/safe-path.js
+++ b/src/safe-path.js
@@ -3,5 +3,5 @@
  * Given a path, replace all characters not recognized by closure-compiler with a '$'
  */
 module.exports = function toSafePath(originalPath) {
-  return originalPath.replace(/[:,?]+/g, '$');
+  return originalPath.replace(/[:,?|]+/g, '$');
 };


### PR DESCRIPTION
Fixes error with paths like `webpack://javascript/esm|C:/Development/...`.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
