### PR TITLE
fix: webpack split chunks incompatibility using IIFE

### DIFF
--- a/src/closure-compiler-plugin.js
+++ b/src/closure-compiler-plugin.js
@@ -1148,7 +1148,7 @@ class ClosureCompilerPlugin {
         name: safeChunkName,
         parentNames: new Set(),
         sources: chunkSources,
-        outputWrapper: '(function(){%s}).call(this || window)',
+        outputWrapper: '%s',
       };
       if (parentChunkNames) {
         parentChunkNames.forEach((parentName) => {


### PR DESCRIPTION
Remove IIFE wrapper on standard build since it prevent multiple Webpack entries and/or chunks for working correctly. 

This is also one way to ask for confirmation on what is the purpose of IIFE in standard build? 