### PR TITLE
chore: add funding field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "src",
     "schema"
   ],
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/webpack"
+  },
   "scripts": {
     "commitlint": "commitlint",
     "commitmsg": "commitlint -e $GIT_PARAMS",


### PR DESCRIPTION
Adds funding field to `package.json` to show fund this package button in npmjs.org. All other plugins and loaders have this 