### PR TITLE
Properly handle export from statements

### DIFF
--- a/src/closure-compiler-plugin.js
+++ b/src/closure-compiler-plugin.js
@@ -14,6 +14,7 @@ const ModuleTemplate = require('webpack/lib/ModuleTemplate');
 const ClosureRuntimeTemplate = require('./closure-runtime-template');
 const HarmonyParserPlugin = require('./dependencies/harmony-parser-plugin');
 const HarmonyExportDependency = require('./dependencies/harmony-export-dependency');
+const HarmonyExportImportDependency = require('./dependencies/harmony-export-import-dependency');
 const HarmonyImportDependency = require('./dependencies/harmony-import-dependency');
 const HarmonyMarkerDependency = require('./dependencies/harmony-marker-dependency');
 const HarmonyNoopTemplate = require('./dependencies/harmony-noop-template');
@@ -231,20 +232,12 @@ class ClosureCompilerPlugin {
         new HarmonyExportDependency.Template()
       );
       compilation.dependencyFactories.set(
-        HarmonyExportDependency,
+        HarmonyExportImportDependency,
         normalModuleFactory
       );
       compilation.dependencyTemplates.set(
-        HarmonyExportDependency,
-        new HarmonyExportDependency.Template()
-      );
-      compilation.dependencyFactories.set(
-        HarmonyExportDependency,
-        normalModuleFactory
-      );
-      compilation.dependencyTemplates.set(
-        HarmonyExportDependency,
-        new HarmonyExportDependency.Template()
+        HarmonyExportImportDependency,
+        new HarmonyExportImportDependency.Template()
       );
       compilation.dependencyFactories.set(
         HarmonyImportDependency,

--- a/src/dependencies/harmony-export-dependency.js
+++ b/src/dependencies/harmony-export-dependency.js
@@ -1,11 +1,11 @@
 const NullDependency = require('webpack/lib/dependencies/NullDependency');
+const HarmonyNoopTemplate = require('./harmony-noop-template')
 
 class ClosureHarmonyExportDependency extends NullDependency {
   constructor(declaration, rangeStatement, module, name, id) {
     super();
     this.declaration = declaration;
     this.rangeStatement = rangeStatement;
-    this.originModule = module;
     this.name = name;
     this.id = id;
   }
@@ -28,17 +28,6 @@ class ClosureHarmonyExportDependency extends NullDependency {
   }
 }
 
-ClosureHarmonyExportDependency.Template = class ClosureHarmonyExportDependencyTemplate {
-  apply(dep, source) {
-    const used = dep.originModule.isUsed(dep.name);
-    if (!used) {
-      const replaceUntil =
-        dep.declaration && dep.declaration.range
-          ? dep.declaration.range[0] - 1
-          : dep.rangeStatement[1] - 1;
-      source.replace(dep.rangeStatement[0], replaceUntil, '');
-    }
-  }
-};
+ClosureHarmonyExportDependency.Template = HarmonyNoopTemplate;
 
 module.exports = ClosureHarmonyExportDependency;

--- a/src/dependencies/harmony-export-import-dependency.js
+++ b/src/dependencies/harmony-export-import-dependency.js
@@ -1,0 +1,23 @@
+const HarmonyImportDependency = require('webpack/lib/dependencies/HarmonyImportDependency');
+
+class ClosureHarmonyExportImportDependency extends HarmonyImportDependency {
+  constructor(request, originModule, sourceOrder, parserScope, range) {
+    super(request, originModule, sourceOrder, parserScope);
+    this.range = range;
+  }
+  updateHash(hash) {
+    hash.update('ClosureHarmonyExportImportDependency');
+  }
+}
+
+ClosureHarmonyExportImportDependency.Template = class ClosureHarmonyExportImportDependencyTemplate {
+  apply(dep, source, runtime) {
+    const moduleId = runtime.moduleId({
+      module: dep._module,
+      request: dep._request,
+    });
+    source.replace(dep.range[0], dep.range[1] - 1, JSON.stringify(moduleId));
+  }
+}
+
+module.exports = ClosureHarmonyExportImportDependency;

--- a/src/dependencies/harmony-import-dependency.js
+++ b/src/dependencies/harmony-import-dependency.js
@@ -12,7 +12,7 @@ ClosureHarmonyImportDependency.Template = class ClosureHarmonyImportDependencyTe
       module: dep._module,
       request: dep._request,
     });
-    source.replace(dep.range[0], dep.range[1], JSON.stringify(moduleId));
+    source.replace(dep.range[0], dep.range[1] - 1, JSON.stringify(moduleId));
   }
 };
 


### PR DESCRIPTION
Certain export from statements were not handled at all and caused compilation errors:

Example:

```js
export * from 'bar';
export {foo} from 'bar';
```

This is preventing those statements from being properly handed to closure-compiler in a recognizable form.
